### PR TITLE
Set missing code comments for public methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,3 +1,4 @@
+// Package kerberos provides a JavaScript module for Kerberos authentication.
 package kerberos
 
 import (
@@ -13,12 +14,18 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
+// Client is the main object exposed on the JavaScript API.
+// It's a wrapper that holds a Kerberos configuration and a Kerberos client.
+// It exposes the main [Authenticate] method for Kerberos authentication.
 type Client struct {
 	config  *config.Config
 	kclient *client.Client
 	vu      modules.VU
 }
 
+// Authenticate uses [Client] credentials to acquire a ticket-granting ticket,
+// if needed, and then uses that one to acquire a service ticket for the given
+// Service Principal Name (SPN).
 func (c *Client) Authenticate(spn string) (Token, error) {
 	if c.vu.State() == nil {
 		return "", fmt.Errorf("is not allowed to be used outside of the VU context")
@@ -42,8 +49,12 @@ func (c *Client) Authenticate(spn string) (Token, error) {
 	return Token(base64.StdEncoding.EncodeToString(nb)), nil
 }
 
+// Token is a base64-encoded token that holds a Kerberos service ticket.
 type Token string
 
+// NegotiateHeader returns the token in a format that can be used in the
+// Authentication header of an HTTP request against a service using
+// Kerberos authentication.
 func (t Token) NegotiateHeader() string {
 	return "Negotiate " + string(t)
 }

--- a/module.go
+++ b/module.go
@@ -41,13 +41,16 @@ func New() *RootModule {
 	return &RootModule{}
 }
 
-// NewModuleInstance implements the modules.Module interface returning a new instance for each VU.
+// NewModuleInstance implements the modules.Module interface returning a new
+// instance for each VU.
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	return &ModuleInstance{
 		vu: vu,
 	}
 }
 
+// Exports implements the [modules.Instance] interface and returns the exports
+// of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{Named: map[string]interface{}{
 		"Client": mi.newClient,


### PR DESCRIPTION
It adds some missing code comments the linter (`revive`) is complaining about.