### PR TITLE
Copy kadm5.acl to /var/lib/krb5kdc when building example

### DIFF
--- a/examples/krb5/Dockerfile.server
+++ b/examples/krb5/Dockerfile.server
@@ -12,7 +12,7 @@ ENTRYPOINT ["/opt/krb5/bin/start.sh"]
 COPY krb5.conf /etc/krb5.conf
 
 # Copy the Kerberos ACL configuration file
-COPY kadm5.acl /etc/krb5kdc/kadm5.acl
+COPY kadm5.acl /var/lib/krb5kdc/kadm5.acl
 
 # Copy the initialization script (it creates the Kerberos database, etc)
 COPY krb5kdc-init.sh /opt/krb5/bin/krb5kdc-init.sh


### PR DESCRIPTION
It seems like `kadmind` expects ACL file to be in `/var/lib` instead of `/etc`, otherwise  starting `examples/krb5/Dockerfile.server` produces following error:
```
krb5-kerberos-server-1  | kadmind: Cannot open /var/lib/krb5kdc/kadm5.acl: Invalid argument while initializing ACL file, aborting
```
