### PR TITLE
Drop the private repo mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check the [example](#example) section below for a extensive and complete impleme
 
 Using the xk6-kerberos extension involves building a k6 binary incorporating it. A detailed guide on how to do this using a Docker or Go environment is available in the [extension's documentation](https://k6.io/docs/extensions/guides/build-a-k6-binary-using-go).
 
-In the current state, as it is a private repository, build directly from the source code using Go could be helpful. We list below the suggested steps:
+In the current state, building directly from the source code using Go could be helpful. We list below the suggested steps:
 
 ### Prepare the local environment
 


### PR DESCRIPTION
As the repo is not private anymore, it drops the specific mention of it in the README.