### PR TITLE
Fix Authorization header usage in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ export default function () {
 
   // Perform an authenticated request to a kerberos-secured HTTP service.
   // Use the returned token to generate a SPNEGO compliant HTTP header to pass to HTTP services.
-  http.get('https://test-api.k6.io', { Authorization: token.negotiateHeader(); });
+  http.get('https://test-api.k6.io', {"headers": {"Authorization": token.negotiateHeader()}});
 }
 ```
 

--- a/examples/script.js
+++ b/examples/script.js
@@ -61,7 +61,7 @@ export default async function () {
   }
 
   // Run HTTP requests using the previously authenticated user.
-  const res = http.get("http://http.example.com", { Authorization: session });
+  const res = http.get("http://http.example.com", {"headers": {"Authorization": session}});
 
   // Simple demonstrative k6 checks.
   check(res, {


### PR DESCRIPTION
Changes _Authorization_  header to be nested in the http GET request.

Closes #42 