### PR TITLE
Add dependabot custom config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "github.com/grafana/gokrb5/*"
+      - dependency-name: "go.k6.io/k6"


### PR DESCRIPTION
We want to update directly only k6 and gokrb. All the other dependencies will be indirectly updated when we update those.