### PR TITLE
chore: flatten Renovate config to extend k6-engine-base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json",
-    "github>grafana/xk6-kerberos//.github/renovate/automerge",
-    "schedule:weekly"
-  ],
-  "timezone": "UTC",
-  "labels": [
-    "dependencies"
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
   ]
 }


### PR DESCRIPTION
Aligns this repo's Renovate config with the rest of the k6 extensions by extending only the shared `github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json` preset.

Part of a broader k6 repo governance clean-up ([grafana/xk6](https://github.com/grafana/xk6)).